### PR TITLE
adjust tests to reflect current template behavior

### DIFF
--- a/tests/ticket_template_test.js
+++ b/tests/ticket_template_test.js
@@ -2,32 +2,61 @@ var jsdom = require('jsdom');
 var expect = require('chai').expect;
 var app = require('../app').app;
 
+var TICKET_VIEW = 'A6_template';
+
 describe('ticket view', function () {
+
 
   it('contains ticket data in view', function (done) {
     var expectedData = {
       id: '12',
       type: 'feature',
       reporter: 'Werner',
-      text: 'Text is good!'
+      title: 'Text is good!',
+      repo: 'doo/bar'
     };
-   
 
-    app.render('ticket', {
+
+    app.render(TICKET_VIEW, {
       ticket: expectedData
     }, function (err, html) {
       jsdom.env({
         html: html,
         done: function (err, window) {
-          var querySelector = window.document.querySelector.bind(window.document);
+          try {
+            var querySelector = window.document.querySelector.bind(window.document);
+            expect(querySelector('.metadata').innerHTML).to.have.string(expectedData.id);
+            expect(querySelector('.ticket-reporter').innerHTML).to.have.string(expectedData.reporter);
+            expect(querySelector('.metadata').innerHTML).to.have.string(expectedData.type);
+            expect(querySelector('.ticket-title').innerHTML).to.have.string(expectedData.title);
+            expect(querySelector('.ticket-repo').innerHTML).to.have.string(expectedData.repo);
 
-          expect(querySelector('.ticket-id').innerHTML).to.have.string(expectedData.id);
-          expect(querySelector('.ticket-reporter').innerHTML).to.have.string(expectedData.reporter);
-          expect(querySelector('.ticket-type').innerHTML).to.have.string(expectedData.type);
-          expect(querySelector('.ticket-text').innerHTML).to.have.string(expectedData.text);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+      });
+    });
+  });
 
+  it('does not contain repo, if there is none set', function (done) {
+    app.render(TICKET_VIEW, {
+      ticket: {}
+    }, function (err, html) {
+      jsdom.env({
+        html: html,
+        done: function (err, window) {
 
-          done();
+          try {
+            var querySelector = window.document.querySelector.bind(window.document);
+            expect(querySelector('.ticket-repo')).to.be.null;
+            done();
+          } catch (e) {
+            console.log(e);
+            done(e);
+          }
+
         }
       });
     });


### PR DESCRIPTION
@filtercake I adjusted the tests, so they test a6 template behavior.

It also just renders the view and omits bootstrapping the whole app for now.

this PR is just fyi :)
